### PR TITLE
Add StatLite to monitoring apps

### DIFF
--- a/data/monitoring.yaml
+++ b/data/monitoring.yaml
@@ -60,3 +60,6 @@
 
 - name: highlight.io
   url: https://github.com/highlight/highlight
+
+- name: StatLite
+  url: 'https://github.com/PVRLabs/statlite'


### PR DESCRIPTION
## Add StatLite

Adds [StatLite](https://github.com/PVRLabs/statlite) to the **Monitoring** section.

StatLite is a lightweight, self-hosted application monitoring dashboard designed for VPSs, homelabs, and small servers.

- Single Go binary with a small resource footprint
- SQLite storage
- Spring Boot and Quarkus monitoring
- Health, traffic, latency, CPU, memory, and optional host metrics
- Docker and native Linux/macOS installation
- No Prometheus/Grafana stack required

StatLite is MIT licensed and designed specifically for small self-hosted deployments.